### PR TITLE
#29402 Flame publish paths from nuke now always written out in Linux format

### DIFF
--- a/hooks/multi_publish/nuke/secondary_publish.py
+++ b/hooks/multi_publish/nuke/secondary_publish.py
@@ -19,7 +19,6 @@ import xml.dom.minidom as minidom
 
 import tank
 from tank import Hook
-from tank import TemplatePath
 from tank import TankError
 
 class PublishHook(Hook):

--- a/hooks/multi_publish/nuke/secondary_publish.py
+++ b/hooks/multi_publish/nuke/secondary_publish.py
@@ -661,7 +661,7 @@ class PublishHook(Hook):
         # because the "hub" platform is always linux (with potential flame assist and flare
         # satellite setups on macosx), request that the paths are written out on linux form
         # regardless of the operating system currently running.
-        publish_path_flame = publish_template.apply_fields(render_path_fields, TemplatePath.PLATFORM_LINUX)
+        publish_path_flame = publish_template.apply_fields(render_path_fields, "linux2")
         
         # open up and update our xml file        
         xml = minidom.parse(clip_path)

--- a/hooks/multi_publish/nuke/secondary_publish.py
+++ b/hooks/multi_publish/nuke/secondary_publish.py
@@ -656,8 +656,11 @@ class PublishHook(Hook):
         # and lastly plug in the values
         render_path_fields["SEQ"] = format_str % (min_frame, max_frame) 
         
-        # contruct the final path             
-        publish_path_flame = publish_template.apply_fields(render_path_fields)
+        # contruct the final path - because flame doesn't have any windows support and 
+        # because the "hub" platform is always linux (with potential flame assist and flare
+        # satellite setups on macosx), request that the paths are written out on linux form
+        # regardless of the operating system currently running.
+        publish_path_flame = publish_template.apply_fields(render_path_fields, self.parent.tank.PLATFORM_LINUX)
         
         # open up and update our xml file        
         xml = minidom.parse(clip_path)

--- a/hooks/multi_publish/nuke/secondary_publish.py
+++ b/hooks/multi_publish/nuke/secondary_publish.py
@@ -19,6 +19,7 @@ import xml.dom.minidom as minidom
 
 import tank
 from tank import Hook
+from tank import TemplatePath
 from tank import TankError
 
 class PublishHook(Hook):
@@ -660,7 +661,7 @@ class PublishHook(Hook):
         # because the "hub" platform is always linux (with potential flame assist and flare
         # satellite setups on macosx), request that the paths are written out on linux form
         # regardless of the operating system currently running.
-        publish_path_flame = publish_template.apply_fields(render_path_fields, self.parent.tank.PLATFORM_LINUX)
+        publish_path_flame = publish_template.apply_fields(render_path_fields, TemplatePath.PLATFORM_LINUX)
         
         # open up and update our xml file        
         xml = minidom.parse(clip_path)

--- a/info.yml
+++ b/info.yml
@@ -16,5 +16,5 @@ description: "This is the same as the Default configuration but also includes th
 
 # Required minimum versions for this item to run
 requires_shotgun_version: "v4.3.9"
-requires_core_version: "v0.15.23"
+requires_core_version: "v0.16.15"
  

--- a/info.yml
+++ b/info.yml
@@ -16,5 +16,5 @@ description: "This is the same as the Default configuration but also includes th
 
 # Required minimum versions for this item to run
 requires_shotgun_version: "v4.3.9"
-requires_core_version: "v0.14.66"
+requires_core_version: "v0.15.23"
  


### PR DESCRIPTION
Uses the new `platform` parameter in `apply_fields` to ensure that paths written out into the open clip xml file (as part of the nuke export) are written as linux paths regardless of platform. This ensures that Flame understands them and can process them correctly, even if the nuke session was running on for example windows.