### PR TITLE
#33079 Flame 2016.1 proxy support, flame on mac and flame batch for shots

### DIFF
--- a/env/asset.yml
+++ b/env/asset.yml
@@ -42,10 +42,9 @@ engines:
       tk-multi-workfiles: '@workfiles'
     debug_logging: false
     location:
-      name: tk-3dsmax
+      version: v0.3.6
       type: app_store
-      version: v0.3.5
-
+      name: tk-3dsmax
   #
   # -------------------------------------------------
   # 3dsmax plus

--- a/env/asset.yml
+++ b/env/asset.yml
@@ -62,7 +62,6 @@ engines:
       type: app_store
       version: v0.1.8
     menu_favourites: []
-
   #
   # -------------------------------------------------
   # Mari
@@ -98,10 +97,9 @@ engines:
     compatibility_dialog_min_version: 2
     debug_logging: false
     location:
-      name: tk-mari
+      version: v1.1.0
       type: app_store
-      version: v1.0.2
-
+      name: tk-mari
   #
   # -------------------------------------------------
   # Maya
@@ -163,7 +161,6 @@ engines:
     timeline_context_menu: []
     bin_context_menu: []
     spreadsheet_context_menu: []
-
   #
   # -------------------------------------------------
   # Photoshop

--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -124,10 +124,9 @@ engines:
         version_compare_ignore_fields: []
     debug_logging: false
     location:
-      name: tk-3dsmax
+      version: v0.3.6
       type: app_store
-      version: v0.3.5
-
+      name: tk-3dsmax
   #
   # -------------------------------------------------
   # 3dsmax Plus

--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -232,7 +232,6 @@ engines:
       type: app_store
       version: v0.1.8
     menu_favourites: []
-
   #
   # -------------------------------------------------
   # Houdini
@@ -434,10 +433,9 @@ engines:
     compatibility_dialog_min_version: 2
     debug_logging: false
     location:
-      name: tk-mari
+      version: v1.1.0
       type: app_store
-      version: v1.0.2
-
+      name: tk-mari
   #
   # -------------------------------------------------
   # Maya

--- a/env/includes/app_launchers.yml
+++ b/env/includes/app_launchers.yml
@@ -307,12 +307,13 @@ launch_screeningroom:
   enable_rv_mode: true
   enable_web_mode: true
   location:
-    name: tk-multi-screeningroom
+    version: v0.2.0
     type: app_store
-    version: v0.1.10
+    name: tk-multi-screeningroom
   rv_path_linux: '@rv_linux'
   rv_path_mac: '@rv_mac'
   rv_path_windows: '@rv_win'
+  init_hook: '{self}/init.py'
 #
 # -------------------------------------------------
 # Softimage

--- a/env/includes/app_launchers.yml
+++ b/env/includes/app_launchers.yml
@@ -37,7 +37,7 @@ launch_3dsmax:
   linux_args: ''
   linux_path: ''
   location:
-    version: v0.6.6
+    version: v0.6.7
     type: app_store
     name: tk-multi-launchapp
   mac_args: ''
@@ -46,7 +46,6 @@ launch_3dsmax:
   versions: []
   windows_args: ''
   windows_path: '@3dsmax_windows'
-
 #
 # -------------------------------------------------
 # Flame
@@ -61,16 +60,15 @@ launch_flame:
   linux_args: ''
   linux_path: '@flame_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: '@flame_mac'
   menu_name: Launch Flame
   versions: []
   windows_args: ''
   windows_path: ''
-
 #
 # -------------------------------------------------
 # Flame Premium
@@ -85,16 +83,15 @@ launch_flame_premium:
   linux_args: ''
   linux_path: '@flame_premium_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: '@flame_premium_mac'
   menu_name: Launch FlamePremium # note: desktop app means we cannot have spaces in app name
   versions: []
   windows_args: ''
   windows_path: ''
-
 #
 # -------------------------------------------------
 # Flame Assist
@@ -109,16 +106,15 @@ launch_flame_assist:
   linux_args: ''
   linux_path: '@flame_assist_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: '@flame_assist_mac'
   menu_name: Launch FlameAssist
   versions: []
   windows_args: ''
   windows_path: ''
-
 #
 # -------------------------------------------------
 # Flare
@@ -133,18 +129,15 @@ launch_flare:
   linux_args: ''
   linux_path: '@flare_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: '@flare_mac'
   menu_name: Launch Flare
   versions: []
   windows_args: ''
   windows_path: ''
-
-
-
 #
 # -------------------------------------------------
 # Hiero
@@ -156,17 +149,17 @@ launch_hiero:
   hook_app_launch: default
   hook_before_app_launch: default
   icon: '{target_engine}/icon_hiero_256.png'
-  linux_args: '--hiero'
+  linux_args: --hiero
   linux_path: '@hiero_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
-  mac_args: '--hiero'
+    name: tk-multi-launchapp
+  mac_args: --hiero
   mac_path: '@hiero_mac'
   menu_name: Launch Hiero
   versions: []
-  windows_args: '--hiero'
+  windows_args: --hiero
   windows_path: '@hiero_win'
 #
 # -------------------------------------------------
@@ -182,9 +175,9 @@ launch_houdini:
   linux_args: ''
   linux_path: '@houdini_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: ''
   menu_name: Launch Houdini
@@ -205,9 +198,9 @@ launch_mari:
   linux_args: ''
   linux_path: '@mari_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: '@mari_mac'
   menu_name: Launch Mari
@@ -228,9 +221,9 @@ launch_maya:
   linux_args: ''
   linux_path: '@maya_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: '@maya_mac'
   menu_name: Launch Maya
@@ -251,9 +244,9 @@ launch_motionbuilder:
   linux_args: ''
   linux_path: ''
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: ''
   menu_name: Launch MotionBuilder
@@ -274,9 +267,9 @@ launch_nuke:
   linux_args: ''
   linux_path: '@nuke_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: '@nuke_mac'
   menu_name: Launch Nuke
@@ -297,9 +290,9 @@ launch_photoshop:
   linux_args: ''
   linux_path: ''
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: '@photoshop_mac'
   menu_name: Launch Photoshop
@@ -334,9 +327,9 @@ launch_softimage:
   linux_args: ''
   linux_path: '@softimage_linux'
   location:
-    name: tk-multi-launchapp
+    version: v0.6.7
     type: app_store
-    version: v0.6.6
+    name: tk-multi-launchapp
   mac_args: ''
   mac_path: ''
   menu_name: Launch Softimage

--- a/env/includes/app_launchers.yml
+++ b/env/includes/app_launchers.yml
@@ -65,7 +65,7 @@ launch_flame:
     type: app_store
     version: v0.6.6
   mac_args: ''
-  mac_path: ''
+  mac_path: '@flame_mac'
   menu_name: Launch Flame
   versions: []
   windows_args: ''
@@ -89,7 +89,7 @@ launch_flame_premium:
     type: app_store
     version: v0.6.6
   mac_args: ''
-  mac_path: ''
+  mac_path: '@flame_premium_mac'
   menu_name: Launch FlamePremium # note: desktop app means we cannot have spaces in app name
   versions: []
   windows_args: ''

--- a/env/includes/flame.yml
+++ b/env/includes/flame.yml
@@ -69,7 +69,7 @@ std_flame_flare:
   #
   debug_logging: false
   location:
-    version: v1.5.1
+    version: v1.5.2
     type: app_store
     name: tk-flame
   project_startup_hook: '{self}/project_startup.py'

--- a/env/includes/flame.yml
+++ b/env/includes/flame.yml
@@ -69,7 +69,7 @@ std_flame_flare:
   #
   debug_logging: false
   location:
-    version: v1.5.3
+    version: v1.5.4
     type: app_store
     name: tk-flame
   project_startup_hook: '{self}/project_startup.py'

--- a/env/includes/flame.yml
+++ b/env/includes/flame.yml
@@ -69,7 +69,7 @@ std_flame_flare:
   #
   debug_logging: false
   location:
-    version: v1.5.2
+    version: v1.5.3
     type: app_store
     name: tk-flame
   project_startup_hook: '{self}/project_startup.py'

--- a/env/includes/flame.yml
+++ b/env/includes/flame.yml
@@ -69,7 +69,7 @@ std_flame_flare:
   #
   debug_logging: false
   location:
-    version: v1.5.4
+    version: v1.5.5
     type: app_store
     name: tk-flame
   project_startup_hook: '{self}/project_startup.py'

--- a/env/includes/flame.yml
+++ b/env/includes/flame.yml
@@ -69,7 +69,7 @@ std_flame_flare:
   #
   debug_logging: false
   location:
-    version: v1.4.2
+    version: v1.5.1
     type: app_store
     name: tk-flame
   project_startup_hook: '{self}/project_startup.py'

--- a/env/includes/paths.yml
+++ b/env/includes/paths.yml
@@ -82,11 +82,13 @@ hiero_linux: Nuke9.0
 # Flame
 #
 flame_linux: /usr/discreet/flame_2016.1/bin/startApplication
+flame_mac: /usr/discreet/flame_2016.1/bin/startApplication
 
 #
 # Flame Premium
 #
 flame_premium_linux: /usr/discreet/flamepremium_2016.1/bin/startApplication
+flame_premium_mac: /usr/discreet/flamepremium_2016.1/bin/startApplication
 
 #
 # Flame Assist

--- a/env/includes/paths.yml
+++ b/env/includes/paths.yml
@@ -81,26 +81,26 @@ hiero_linux: Nuke9.0
 #
 # Flame
 #
-flame_linux: /usr/discreet/flame_2016.1/bin/startApplication
-flame_mac: /usr/discreet/flame_2016.1/bin/startApplication
+flame_linux: /usr/discreet/flame_2016.1.1/bin/startApplication
+flame_mac: /usr/discreet/flame_2016.1.1/bin/startApplication
 
 #
 # Flame Premium
 #
-flame_premium_linux: /usr/discreet/flamepremium_2016.1/bin/startApplication
-flame_premium_mac: /usr/discreet/flamepremium_2016.1/bin/startApplication
+flame_premium_linux: /usr/discreet/flamepremium_2016.1.1/bin/startApplication
+flame_premium_mac: /usr/discreet/flamepremium_2016.1.1/bin/startApplication
 
 #
 # Flame Assist
 #
-flame_assist_mac: /usr/discreet/flameassist_2016.1/bin/startApplication
-flame_assist_linux: /usr/discreet/flameassist_2016.1/bin/startApplication
+flame_assist_mac: /usr/discreet/flameassist_2016.1.1/bin/startApplication
+flame_assist_linux: /usr/discreet/flameassist_2016.1.1/bin/startApplication
 
 #
 # Flare
 #
-flare_mac: /usr/discreet/flare_2016.1/bin/startApplication
-flare_linux: /usr/discreet/flare_2016.1/bin/startApplication
+flare_mac: /usr/discreet/flare_2016.1.1/bin/startApplication
+flare_linux: /usr/discreet/flare_2016.1.1/bin/startApplication
 
 
 #

--- a/env/project.yml
+++ b/env/project.yml
@@ -366,6 +366,10 @@ engines:
       tk-multi-launchphotoshop: '@launch_photoshop'
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-launchflame: '@launch_flame'
+      tk-multi-launchflare: '@launch_flare'
+      tk-multi-launchflameassist: '@launch_flame_assist'
+      tk-multi-launchflamepremium: '@launch_flame_premium'      
     location:
       name: tk-shell
       type: app_store

--- a/env/project.yml
+++ b/env/project.yml
@@ -59,7 +59,6 @@ engines:
       type: app_store
       version: v0.1.8
     menu_favourites: []
-
   #
   # -------------------------------------------------
   # Shotgun Desktop
@@ -233,7 +232,6 @@ engines:
     timeline_context_menu:
     - {app_instance: tk-hiero-openinshotgun, keep_in_menu: false, name: Open in Shotgun,
       requires_selection: true}
-
   #
   # -------------------------------------------------
   # Mari
@@ -269,10 +267,9 @@ engines:
     compatibility_dialog_min_version: 2
     debug_logging: false
     location:
-      name: tk-mari
+      version: v1.1.0
       type: app_store
-      version: v1.0.2
-
+      name: tk-mari
   #
   # -------------------------------------------------
   # Maya
@@ -335,7 +332,6 @@ engines:
     timeline_context_menu: []
     bin_context_menu: []
     spreadsheet_context_menu: []
-
   #
   # -------------------------------------------------
   # Photoshop
@@ -369,7 +365,7 @@ engines:
       tk-multi-launchflame: '@launch_flame'
       tk-multi-launchflare: '@launch_flare'
       tk-multi-launchflameassist: '@launch_flame_assist'
-      tk-multi-launchflamepremium: '@launch_flame_premium'      
+      tk-multi-launchflamepremium: '@launch_flame_premium'
     location:
       name: tk-shell
       type: app_store

--- a/env/project.yml
+++ b/env/project.yml
@@ -39,10 +39,9 @@ engines:
       tk-multi-workfiles: '@workfiles'
     debug_logging: false
     location:
-      name: tk-3dsmax
+      version: v0.3.6
       type: app_store
-      version: v0.3.5
-
+      name: tk-3dsmax
   #
   # -------------------------------------------------
   # 3dsmax plus

--- a/env/sequence.yml
+++ b/env/sequence.yml
@@ -43,10 +43,9 @@ engines:
       tk-multi-workfiles: '@workfiles'
     debug_logging: false
     location:
-      name: tk-3dsmax
+      version: v0.3.6
       type: app_store
-      version: v0.3.5
-
+      name: tk-3dsmax
   #
   # -------------------------------------------------
   # 3dsmax plus
@@ -63,7 +62,6 @@ engines:
       type: app_store
       version: v0.1.8
     menu_favourites: []
-
   #
   # -------------------------------------------------
   # Maya
@@ -125,7 +123,6 @@ engines:
     timeline_context_menu: []
     bin_context_menu: []
     spreadsheet_context_menu: []
-
   #
   # -------------------------------------------------
   # Shell (tank command)

--- a/env/shot.yml
+++ b/env/shot.yml
@@ -142,6 +142,16 @@ engines:
       type: app_store
       version: v0.3.2
 
+  #
+  # -------------------------------------------------
+  # Flame
+  # -------------------------------------------------
+  tk-flame: '@std_flame_flare'
+
+  #
+  # -------------------------------------------------
+  # Flare
+  # -------------------------------------------------
   tk-flare: '@std_flame_flare'
 
   #
@@ -155,6 +165,8 @@ engines:
       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
       tk-multi-launchnuke: '@launch_nuke'
       tk-multi-launchflare: '@launch_flare'
+      tk-multi-launchflamepremium: '@launch_flame_premium'
+      tk-multi-launchflame: '@launch_flame'      
       tk-multi-launchphotoshop: '@launch_photoshop'
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'

--- a/env/shot.yml
+++ b/env/shot.yml
@@ -44,10 +44,9 @@ engines:
       tk-multi-workfiles: '@workfiles'
     debug_logging: false
     location:
-      name: tk-3dsmax
+      version: v0.3.6
       type: app_store
-      version: v0.3.5
-
+      name: tk-3dsmax
   #
   # -------------------------------------------------
   # 3dsmax plus
@@ -64,7 +63,6 @@ engines:
       type: app_store
       version: v0.1.8
     menu_favourites: []
-
   #
   # -------------------------------------------------
   # maya
@@ -126,7 +124,6 @@ engines:
     timeline_context_menu: []
     bin_context_menu: []
     spreadsheet_context_menu: []
-
   #
   # -------------------------------------------------
   # Photoshop
@@ -147,13 +144,11 @@ engines:
   # Flame
   # -------------------------------------------------
   tk-flame: '@std_flame_flare'
-
   #
   # -------------------------------------------------
   # Flare
   # -------------------------------------------------
   tk-flare: '@std_flame_flare'
-
   #
   # -------------------------------------------------
   # Shell (tank command)
@@ -166,7 +161,7 @@ engines:
       tk-multi-launchnuke: '@launch_nuke'
       tk-multi-launchflare: '@launch_flare'
       tk-multi-launchflamepremium: '@launch_flame_premium'
-      tk-multi-launchflame: '@launch_flame'      
+      tk-multi-launchflame: '@launch_flame'
       tk-multi-launchphotoshop: '@launch_photoshop'
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'

--- a/env/shot_step.yml
+++ b/env/shot_step.yml
@@ -130,10 +130,9 @@ engines:
         version_compare_ignore_fields: []
     debug_logging: false
     location:
-      name: tk-3dsmax
+      version: v0.3.6
       type: app_store
-      version: v0.3.5
-
+      name: tk-3dsmax
   #
   # -------------------------------------------------
   # 3dsmax plus
@@ -248,7 +247,6 @@ engines:
       type: app_store
       version: v0.1.8
     menu_favourites: []
-
   #
   # -------------------------------------------------
   # houdini
@@ -840,7 +838,6 @@ engines:
     timeline_context_menu: []
     bin_context_menu: []
     spreadsheet_context_menu: []
-
   #
   # -------------------------------------------------
   # photoshop

--- a/env/shotgun_shot.yml
+++ b/env/shotgun_shot.yml
@@ -35,6 +35,8 @@ engines:
       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
       tk-multi-launchnuke: '@launch_nuke'
       tk-multi-launchflare: '@launch_flare'
+      tk-multi-launchflamepremium: '@launch_flame_premium'
+      tk-multi-launchflame: '@launch_flame'
       tk-multi-launchphotoshop: '@launch_photoshop'
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'


### PR DESCRIPTION
- This introduces an upgraded engine which supports the new proxy settings for flame 2016.1. 
- It also handles flame in batch mode when launched from a Shot.
- The configuration adds paths for flame on mac
- The configuration bumps the default version to Flame 2016 Ext 1 SP 1